### PR TITLE
add missing instruction in selection sort program

### DIFF
--- a/Code-Samples/Selection-Sort/selection-sort.acore
+++ b/Code-Samples/Selection-Sort/selection-sort.acore
@@ -8,8 +8,8 @@
 @C0060: 0040203 0100205 0044071 0130054 0130057 0130205 0130202 0070054 
 @C0070: 0100206 0040000 0100203 0040000 0130044 0130070 0130204 0130201 
 @C0100: 0070042 0000000  None    None    None    None    None    None   
-@C0200: 0000010 0000000 0000000 0000000 0000206 0000000 0000004 0000003 
-@C0210: 0000011 0000030 0000023 0000007 0000004 0000000 0000011 0000025 
+@C0200: 0000010 0000000 0000000 0000000 0000206 0000000 0000004 0000011 
+@C0210: 0000010 0000003 0000002 0000012 0000005 0000006 0000007 0000001 
 @S0040: main
 @S0042: loop
 @S0044: load1
@@ -23,42 +23,42 @@
 @S0201: count1
 @S0202: count2
 @S0203: max
-@S0204: x1
-@S0205: x2
+@S0204: xi
+@S0205: xj
 @S0206: data
 @E0070: print(f"### max: {py_int(cm.rd(rl('max')))} ###")
-@E0074: for i in range(0, 10): print(f"### data[{i}] = {py_int(cm.rd(rl('data') + i))} ###")
+@E0074: for i in range(10): print(f"### data[{i}] = {py_int(cm.rd(rl('data') + i))} ###")
 @N0040: load initial value for outer loop counter
 @N0041: reset outer loop counter
 @N0042: load initial value for inner loop counter
 @N0043: reset inner counter
-@N0044: load x1
-@N0045: x1 is max for now
-@N0046: load address of x1
-@N0047: copy address of x1 into instruction
-@N0050: store address of x1 as address of x2
-@N0051: store address of x1 + 1 as address of x2
-@N0052: copy address of x2 into instruction
-@N0053: copy address of x2 into instruction
-@N0054: load value of x2
-@N0055: compare x2 to max
+@N0044: load xi
+@N0045: xi is max for now
+@N0046: load address of xi
+@N0047: copy address of xi into instruction
+@N0050: store address of xi as address of xj
+@N0051: store address of xi + 1 as address of xj
+@N0052: copy address of xj into instruction
+@N0053: copy address of xj into instruction
+@N0054: load value of xj
+@N0055: compare xj to max
 @N0056: jump if smaller than max
-@N0057: load value of x2
-@N0060: x2 is the new max
+@N0057: load value of xj
+@N0060: xj is the new max
 @N0061: load address of max
 @N0062: copy address of max into instruction
-@N0063: increment x2 address
-@N0064: increment x2 address
-@N0065: increment x2 address
+@N0063: increment xj address
+@N0064: increment xj address
+@N0065: increment xj address
 @N0066: increment inner loop counter
 @N0067: continue inner loop if counter hasn't expired
 @N0070: load value to swap
 @N0071: write value to address of max
 @N0072: load value to swap
-@N0073: write value to address of x1
-@N0074: increment x1 address
-@N0075: increment x1 address
-@N0076: increment x1 address
+@N0073: write value to address of xi
+@N0074: increment xi address
+@N0075: increment xi address
+@N0076: increment xi address
 @N0077: increment outer loop counter
 @N0100: continue outer loop if counter hasn't expired
 @N0101: halt
@@ -66,5 +66,5 @@
 @N0201: outer loop counter
 @N0202: inner loop counter
 @N0203: maximum value seen in this inner loop
-@N0204: address of x1
-@N0205: address of x2
+@N0204: address of xi
+@N0205: address of xj

--- a/Code-Samples/Selection-Sort/selection-sort.lst
+++ b/Code-Samples/Selection-Sort/selection-sort.lst
@@ -9,35 +9,36 @@
 @0041:040201            ts   count1    ; reset outer loop counter 
 @0042:100201      loop: ca   count1    ; load initial value for inner loop counter @@JumpedToBy a0100 
 @0043:040202            ts   count2    ; reset inner counter 
-@0044:100206     load1: ca   data      ; load x1 @@WrittenBy a0074 ReadBy a0074 
-@0045:040203            ts   max       ; x1 is max for now 
-@0046:100204            ca   x1        ; load address of x1 
-@0047:044073            td   swap2     ; copy address of x1 into instruction 
-@0050:040205            ts   x2        ; store address of x1 as address of x2 
-@0051:130205            ao   x2        ; store address of x1 + 1 as address of x2 
-@0052:044054            td   if        ; copy address of x2 into instruction 
-@0053:044057            td   then      ; copy address of x2 into instruction 
-@0054:100000        if: ca   0         ; load value of x2 @@JumpedToBy a0067 WrittenBy a0052 endif ReadBy endif 
-@0055:114203            su   max       ; compare x2 to max 
+@0044:100206     load1: ca   data      ; load xi @@WrittenBy a0074 ReadBy a0074 
+@0045:040203            ts   max       ; xi is max for now 
+@0046:100204            ca   xi        ; load address of xi 
+                        ; td swap1         ; copy address of xi into instruction
+@0047:044073            td   swap2     ; copy address of xi into instruction 
+@0050:040205            ts   xj        ; store address of xi as address of xj 
+@0051:130205            ao   xj        ; store address of xi + 1 as address of xj 
+@0052:044054            td   if        ; copy address of xj into instruction 
+@0053:044057            td   then      ; copy address of xj into instruction 
+@0054:100000        if: ca   0         ; load value of xj @@JumpedToBy a0067 WrittenBy a0052 endif ReadBy endif 
+@0055:114203            su   max       ; compare xj to max 
 @0056:070063            cp   endif     ; jump if smaller than max 
-@0057:100000      then: ca   0         ; load value of x2 @@WrittenBy a0053 a0064 ReadBy a0064 
-@0060:040203            ts   max       ; x2 is the new max 
-@0061:100205            ca   x2        ; load address of max 
+@0057:100000      then: ca   0         ; load value of xj @@WrittenBy a0053 a0064 ReadBy a0064 
+@0060:040203            ts   max       ; xj is the new max 
+@0061:100205            ca   xj        ; load address of max 
 @0062:044071            td   swap1     ; copy address of max into instruction 
-@0063:130054     endif: ao   if        ; increment x2 address @@JumpedToBy a0056 
-@0064:130057            ao   then      ; increment x2 address 
-@0065:130205            ao   x2        ; increment x2 address 
+@0063:130054     endif: ao   if        ; increment xj address @@JumpedToBy a0056 
+@0064:130057            ao   then      ; increment xj address 
+@0065:130205            ao   xj        ; increment xj address 
 @0066:130202            ao   count2    ; increment inner loop counter 
 @0067:070054            cp   if        ; continue inner loop if counter hasn't expired 
                         .exec print(f"### max: {py_int(cm.rd(rl('max')))} ###")  ;  
 @0070:100206     load2: ca   data      ; load value to swap @@WrittenBy a0075 ReadBy a0075 
 @0071:040000     swap1: ts   0         ; write value to address of max @@WrittenBy a0062 
 @0072:100203            ca   max       ; load value to swap 
-@0073:040000     swap2: ts   0         ; write value to address of x1 @@WrittenBy a0047 
-                        .exec for i in range(0, 10): print(f"### data[{i}] = {py_int(cm.rd(rl('data') + i))} ###")  ;  
-@0074:130044            ao   load1     ; increment x1 address 
-@0075:130070            ao   load2     ; increment x1 address 
-@0076:130204            ao   x1        ; increment x1 address 
+@0073:040000     swap2: ts   0         ; write value to address of xi @@WrittenBy a0047 
+                        .exec for i in range(10): print(f"### data[{i}] = {py_int(cm.rd(rl('data') + i))} ###")  ;  
+@0074:130044            ao   load1     ; increment xi address 
+@0075:130070            ao   load2     ; increment xi address 
+@0076:130204            ao   xi        ; increment xi address 
 @0077:130201            ao   count1    ; increment outer loop counter 
 @0100:070042            cp   loop      ; continue outer loop if counter hasn't expired 
 @0101:000000            si   0         ; halt 
@@ -47,15 +48,15 @@
 @0201:000000    count1: .word 0.00000   ; outer loop counter @@WrittenBy a0041 a0077 ReadBy loop a0077 
 @0202:000000    count2: .word 0.00000   ; inner loop counter @@WrittenBy a0043 a0066 ReadBy a0066 
 @0203:000000       max: .word 0.00000   ; maximum value seen in this inner loop @@WrittenBy a0045 a0060 ReadBy a0055 a0072 
-@0204:000206        x1: .word data      ; address of x1 @@WrittenBy a0076 ReadBy a0046 a0076 
-@0205:000000        x2: .word 0.00000   ; address of x2 @@WrittenBy a0050 a0051 a0065 ReadBy a0051 a0061 a0065 
+@0204:000206        xi: .word data      ; address of xi @@WrittenBy a0076 ReadBy a0046 a0076 
+@0205:000000        xj: .word 0.00000   ; address of xj @@WrittenBy a0050 a0051 a0065 ReadBy a0051 a0061 a0065 
 @0206:000004      data: .word 0.00004   ;  @@ReadBy load1 load2 
-@0207:000003            .word 0.00003   ;  
-@0210:000011            .word 0.00011   ;  
-@0211:000030            .word 0.00030   ;  
-@0212:000023            .word 0.00023   ;  
-@0213:000007            .word 0.00007   ;  
-@0214:000004            .word 0.00004   ;  
-@0215:000000            .word 0.00000   ;  
-@0216:000011            .word 0.00011   ;  
-@0217:000025            .word 0.00025   ;  
+@0207:000011            .word 0.00011   ;  
+@0210:000010            .word 0.00010   ;  
+@0211:000003            .word 0.00003   ;  
+@0212:000002            .word 0.00002   ;  
+@0213:000012            .word 0.00012   ;  
+@0214:000005            .word 0.00005   ;  
+@0215:000006            .word 0.00006   ;  
+@0216:000007            .word 0.00007   ;  
+@0217:000001            .word 0.00001   ;  

--- a/Code-Samples/Selection-Sort/selection-sort.ww
+++ b/Code-Samples/Selection-Sort/selection-sort.ww
@@ -12,6 +12,7 @@ loop:  ca count1        ; load initial value for inner loop counter
 load1: ca data          ; load xi
        ts max           ; xi is max for now
        ca xi            ; load address of xi
+       td swap1         ; copy address of xi into instruction
        td swap2         ; copy address of xi into instruction
        ts xj            ; store address of xi as address of xj
        ao xj            ; store address of xi + 1 as address of xj
@@ -34,7 +35,7 @@ load2: ca data          ; load value to swap
 swap1: ts 0             ; write value to address of max
        ca max           ; load value to swap
 swap2: ts 0             ; write value to address of xi
-       .exec for i in range(0, 10): print(f"### data[{i}] = {py_int(cm.rd(rl('data') + i))} ###")
+       .exec for i in range(10): print(f"### data[{i}] = {py_int(cm.rd(rl('data') + i))} ###")
        ao load1         ; increment xi address
        ao load2         ; increment xi address
        ao xi            ; increment xi address
@@ -50,12 +51,12 @@ max:   .word 0.00000    ; maximum value seen in this inner loop
 xi:    .word data       ; address of xi
 xj:    .word 0.00000    ; address of xj
 data:  .word 0.00004
+       .word 0.00011
+       .word 0.00010
        .word 0.00003
-       .word 0.00011
-       .word 0.00030
-       .word 0.00023
+       .word 0.00002
+       .word 0.00012
+       .word 0.00005
+       .word 0.00006
        .word 0.00007
-       .word 0.00004
-       .word 0.00000
-       .word 0.00011
-       .word 0.00025
+       .word 0.00001


### PR DESCRIPTION
I was missing a `td swap1` instruction for cases where the first element is already the max.

The rest of this commit is non-substantial.